### PR TITLE
Refer to resource with index even with count 0/1

### DIFF
--- a/lambda_function/schedule_trigger.tf
+++ b/lambda_function/schedule_trigger.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_event_rule" "lambda" {
 resource "aws_cloudwatch_event_target" "lambda" {
   count = "${var.trigger_schedule["enabled"] ? 1 : 0}"
 
-  rule      = "${aws_cloudwatch_event_rule.lambda.name}"
+  rule      = "${aws_cloudwatch_event_rule.lambda[0].name}"
   target_id = "${var.function_name}-target"
   arn       = "${aws_lambda_function.lambda.arn}"
 }
@@ -21,5 +21,5 @@ resource "aws_lambda_permission" "lambda_cloudwatch" {
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.lambda.function_name}"
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.lambda.arn}"
+  source_arn    = "${aws_cloudwatch_event_rule.lambda[0].arn}"
 }


### PR DESCRIPTION
Terraform 0.12.7 compatibility requires that even if count is 0 or 1, we refer to resources with indices.